### PR TITLE
Infrastructure Quadrant Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,27 @@ Feel free to use and adapt it for your own purposes.
 
 ## Usage
 
-configure the radar visualization:
+Entries are added to the `entries` field as needed, with each entry declaring its `quadrant` and `timeline`.
+
+Entries are positioned automatically so that they don't overlap. Each entry will end up in a table
+outside the radar screen and will be a link. You should create headings to match the links describing
+each item on the radar. For example, "React Testing Library" will have a link to "#react-testing-library".
+
+### Timeline
+
+The `timeline` in each entry is to show the historic "movement" of an entry.
+
+A brand new entry would have only one entry in its timeline, but as it moves inward or outward on the rings each movement should be a separate entry in the timeline. The first entry in the timeline is displayed. Each timeline entry captures the date of the movement, a description of the movement, and an optional "direction" via the `moved` field.
+
+The `moved` field conforms to the following:
+
+* `-1` means the entry has momementum or movement outward (triangle pointing down or outward from the center)
+* `0` means the entry no momementum or movement (a simple circle)
+* `1` means the entry has momentum or movement inward (triangle pointing up or inward to the center)
+
+## Example
+
+Here is an example configuration of the radar visualization:
 
 ```js
 radar_visualization({
@@ -51,10 +71,6 @@ radar_visualization({
   ]
 });
 ```
-
-Entries are positioned automatically so that they don't overlap. Each entry will end up in a table
-outside the radar screen and will be a link. You should create headings to match the links describing
-each item on the radar. For example, "React Testing Library" will have a link to "#react-testing-library".
 
 ## Local Development
 

--- a/docs/config.json
+++ b/docs/config.json
@@ -370,6 +370,12 @@
           "moved": 0,
           "ringId": "hold",
           "date": "2022-12-19",
+          "description": "Used for Ingress in places, but no new usage in some time."
+        },
+        {
+          "moved": 0,
+          "ringId": "adopt",
+          "date": "2022-05-1",
           "description": ""
         }
       ],

--- a/docs/config.json
+++ b/docs/config.json
@@ -1121,6 +1121,38 @@
       "title": "DataBricks",
       "quadrant": "data_management",
       "description": ""
+    },
+    {
+      "timeline": [
+        {
+          "moved": 0,
+          "ringId": "hold",
+          "date": "2022-12-21",
+          "description": ""
+        }
+      ],
+      "url": "https://github.com/kubernetes/kops",
+      "key": "kops",
+      "id": "kops",
+      "title": "Kops",
+      "quadrant": "infrastructure",
+      "description": "Kubernetes Cluster Management"
+    },
+    {
+      "timeline": [
+        {
+          "moved": 0,
+          "ringId": "hold",
+          "date": "2022-05-01",
+          "description": ""
+        }
+      ],
+      "url": "#",
+      "key": "docker_desktop",
+      "id": "docker_desktop",
+      "title": "Docker Desktop",
+      "quadrant": "infrastructure",
+      "description": "Container Runtime for Local Development"
     }
   ]
 }

--- a/docs/config.json
+++ b/docs/config.json
@@ -246,9 +246,9 @@
         }
       ],
       "url": "#",
-      "key": "docker",
-      "id": "docker",
-      "title": "Docker",
+      "key": "kubernetes",
+      "id": "kubernetes",
+      "title": "Kubernetes",
       "quadrant": "infrastructure",
       "description": ""
     },
@@ -256,15 +256,15 @@
       "timeline": [
         {
           "moved": 0,
-          "ringId": "adopt",
-          "date": "2022-05-01",
+          "ringId": "trial",
+          "date": "2022-12-19",
           "description": ""
         }
       ],
       "url": "#",
-      "key": "kubernetes",
-      "id": "kubernetes",
-      "title": "Kubernetes",
+      "key": "kubernetes_operators",
+      "id": "kubernetes_operators",
+      "title": "Kubernetes Operators",
       "quadrant": "infrastructure",
       "description": ""
     },
@@ -368,8 +368,8 @@
       "timeline": [
         {
           "moved": 0,
-          "ringId": "adopt",
-          "date": "2022-05-01",
+          "ringId": "hold",
+          "date": "2022-12-19",
           "description": ""
         }
       ],
@@ -480,19 +480,34 @@
       "timeline": [
         {
           "moved": 0,
-          "ringId": "assess",
-          "date": "2022-05-01",
+          "ringId": "trial",
+          "date": "2022-12-19",
           "description": ""
         }
       ],
       "url": "#",
-      "key": "kustomize",
-      "id": "kustomize",
-      "title": "Kustomize",
+      "key": "jsonnet",
+      "id": "jsonnet",
+      "title": "Jsonnet",
+      "quadrant": "languages",
+      "description": ""
+    },
+    {
+      "timeline": [
+        {
+          "moved": 0,
+          "ringId": "assess",
+          "date": "2022-12-19",
+          "description": ""
+        }
+      ],
+      "url": "#",
+      "key": "tanka",
+      "id": "tanka",
+      "title": "Tanka",
       "quadrant": "infrastructure",
       "description": ""
     },
-
     {
       "timeline": [
         {


### PR DESCRIPTION
I finally decided to make some updates here, I'm open to feedback and discussion on any changes.

* Removed `docker`, since our infrastructure is already no longer using it and it will soon be gone with the incoming Kubernetes Upgrade (we already run `containerd` as our Container Runtime with a "dockershim").
  * There still is Docker Desktop usage at Invoca, but that's more local development than infrastructure. Willing to be swayed here.
* Moved `nginx` into the Hold ring, we haven't seen a new usage of `nginx` for some time.
* Added `kubernetes_operators` into the Trial ring, we're using them to solve real problems across the organization in production (and non-production). I don't think we'd adopt any old Kubernetes Operator, but we are successfully running on ones that meet our criteria.
* Removed `kustomize`, it was assessed and deemed not to fit our needs at the moment.
* Added `jsonnet` to the `languages` Quadrant in the Trial ring. Yes I know the PR is titled Infrastructure but I wasn't sure jsonnet fit here, I can be swayed.
* Added `tanka` to the Assess ring, it's being prototyped and making its way into being a part of bootstrapping our infrastructure (and maintaining it).