### PR TITLE
Passion: add support for showing description and timeline when clicking an entry

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
     radar_visualization({
       svg_id: "radar",
       width: 1450,
-      height: 1000,
+      height: 900,
       colors: {
         background: "#fff",
         grid: "#ededed",
@@ -44,7 +44,7 @@
       },
       print_layout: true,
       // Update the year / month if making a new revision
-      title: "Invoca Tech Radar 2023.01",
+      title: "Invoca Tech Radar 2023.04",
 
       // supplied via radar_config.js
       rings: data.rings,
@@ -53,6 +53,12 @@
     });
   });
 </script>
+
+<div class="active-area">
+  <p id="active-title"></p>
+  <p id="active-description"></p>
+  <div id="active-timeline"></div>
+</div>
 
 <table>
 <tr>

--- a/docs/radar.css
+++ b/docs/radar.css
@@ -43,3 +43,19 @@ td {
   vertical-align: top;
   padding-right: 60px;
 }
+
+.active-area {
+  border: 1px solid #ccc;
+  padding: 10px;
+  margin: 0 20px 30px;
+}
+
+#active-title {
+  font-weight: bold;
+  margin-top: 0;
+}
+
+#active-timeline .date {
+  color: #aaa;
+  padding-right; 5px;
+}


### PR DESCRIPTION
We have descriptions (and timelines) for some entries, but have not shown them in the UI. We should! This is a simple hack to get them visible. It also works on reload, so you can share a URL around and have the description/timeline visible.

![image](https://user-images.githubusercontent.com/372310/235605435-a9534c8d-6a78-4e4a-8847-4a6c35ac78af.png)
