### PR TITLE
Add Backstage catalog-info.yaml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Code ownership for this repository
+* @Invoca/octothorpe

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# Code ownership for this repository
-* @Invoca/octothorpe

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -14,4 +14,4 @@ spec:
   type: service
   lifecycle: production
   owner: octothorpe
-  # system: TODO — see https://github.com/Invoca/backstage-catalog
+  system: developer-tooling

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,17 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: tech-radar
+  title: tech-radar
+  description: "Visualizing our technology choices"
+  tags:
+    - javascript
+  annotations:
+    backstage.io/source-location: url:https://github.com/Invoca/tech-radar/
+    github.com/project-slug: Invoca/tech-radar
+    buildkite.com/project-slug: invoca/tech-radar
+spec:
+  type: service
+  lifecycle: production
+  owner: octothorpe
+  # system: TODO — see https://github.com/Invoca/backstage-catalog

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -13,5 +13,5 @@ metadata:
 spec:
   type: service
   lifecycle: production
-  owner: octothorpe
+  owner: dev-managers
   system: developer-tooling


### PR DESCRIPTION
## Add Backstage `catalog-info.yaml`

Registers this repo in the [Invoca Backstage catalog](https://backstage.invoca.net).

### What was auto-generated
- **type**: `service` (inferred from repo name/language)
- **owner**: `octothorpe`
- **system**: `developer-tooling`

### Please review before merging
- [ ] `spec.owner` is correct
- [ ] `spec.system` is set (see [taxonomy](https://github.com/Invoca/backstage-catalog))
- [ ] `metadata.description` is accurate
- [ ] Add `dependsOn`, `providesApis`, or `consumesApis` if relevant

See [voice-agent](https://github.com/Invoca/voice-agent/tree/main/.backstage) for a fully-built example.

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)
